### PR TITLE
feat: removing flutter version from ci since 3.19.4 is now supported

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -31,11 +31,6 @@ jobs:
       - name: 🎯 Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          # TODO(bryanoltman): remove flutter-version specification once we
-          # support 3.19.4. This was added because `flutter create` creates a
-          # flutter project that requires a higher minimum Dart version than
-          # what we support.
-          flutter-version: "3.19.3"
           channel: stable
           cache: true
 
@@ -66,7 +61,7 @@ jobs:
       - name: 🚦 Assert Release Version (MacOS/Linux)
         if: runner.os != 'Windows'
         run: |
-          if [[ ${{ steps.shorebird-release.outputs.release-version }} =~ "0.1.0+1" ]]; then          
+          if [[ ${{ steps.shorebird-release.outputs.release-version }} =~ "0.1.0+1" ]]; then
             echo '✅ Shorebird Release Succeeded!'
           else
             echo '❌ Shorebird Release Failed.'


### PR DESCRIPTION
CI had a flutter version restriction due not support the last version. Removing it since it now does.