### PR TITLE
feat: add first party `--flutter-version` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ steps:
   - uses: shorebirdtech/shorebird-release@v0
     id: shorebird-release
     with:
-      args: --flutter-version=1.2.3 --verbose --flavor=my-flavor --target=lib/special_main.dart
+      args: --verbose --flavor=my-flavor --target=lib/special_main.dart
+      flutter-version: 3.29.2
       platform: android
       working-directory: ./path/to/app
 ```
@@ -48,8 +49,10 @@ steps:
 The action takes the following inputs:
 
 - `args`: Any arguments to pass to `shorebird release`. For example, if you need
-  to use a specific version of Flutter, you can pass `--flutter-version=1.2.3`.
+  to specify a flavor, you can pass `--flavor=<FLAVOR>`.
   - Use an extra `--` to pass arguments to Flutter (e.g. `-- --dart-define=KEY=VALUE`)
+- `flutter-version`: Which Flutter version to build the release with.
+  - Defaults to `latest` which uses the latest stable Flutter version supported by Shorebird.
 - `platform`: Which platform to create a release for (e.g. `android` or `ios`)
 - `working-directory`: Which directory to run `shorebird release` in.
 

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: The arguments to pass to the Shorebird release command
     required: false
     default: ""
+  flutter-version:
+    description: The version of Flutter to use for the release. Defaults to the latest stable version.
+    required: false
+    default: "latest"
   platform:
     description: The platform for which to create a release (e.g. android, ios)
     required: true
@@ -31,7 +35,7 @@ runs:
       id: shorebird-release
       working-directory: ${{ inputs.working-directory }}
       run: |
-        shorebird release ${{ inputs.platform }} ${{ inputs.args }} | tee output.log
+        shorebird release ${{ inputs.platform }} --flutter-version ${{ inputs.flutter-version }} ${{ inputs.args }} | tee output.log
         GREP_MATCH=$(grep -Ei "Published Release (.*)" output.log)
         if [[ $GREP_MATCH ]]; then
           # Strip the non-version-number characters from the line


### PR DESCRIPTION
Adds first party support for specifying a `flutter-version` when releasing. This defaults to the latest stable version and is optional for backward compatibility. We will make it required in the next major version of this action.

Related to https://github.com/shorebirdtech/shorebird/issues/2529