### PR TITLE
fix: shorebird-release fails if args have newlines

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -47,7 +47,7 @@ jobs:
         run: flutter create e2e_test --empty
 
       - name: 🐦 Shorebird Init
-        run: shorebird init --force --organization-id=14235
+        run: shorebird init --force --organization-id=46686
         working-directory: e2e_test
 
       - name: 🐦 Shorebird Release

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -47,6 +47,11 @@ jobs:
         run: flutter create e2e_test --empty
 
       - name: 🐦 Shorebird Init
+        # Org id is tied to the shorebirdtest@gmail.com account that backs
+        # SHOREBIRD_TOKEN. If this id rotates (e.g. the account is recreated),
+        # `shorebird init` will fail with "Organization with ID '...' not
+        # found" and list the new id under "Available organizations" — copy
+        # that id here.
         run: shorebird init --force --organization-id=46686
         working-directory: e2e_test
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@ steps:
   - uses: shorebirdtech/shorebird-release@v1
     id: shorebird-release
     with:
-      args: --verbose --flavor=my-flavor --target=lib/special_main.dart
+      # Use >- to strip newlines if passing args across multiple lines.
+      args: >-
+        --verbose
+        --flavor=my-flavor
+        --target=lib/special_main.dart
       flutter-version: 3.29.2
       platform: android
       working-directory: ./path/to/app

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     default: ""
   flutter-version:
     description: The version of Flutter to use for the release. Use "latest" to always target the latest stable version.
-    required: true    
+    required: true
   platform:
     description: The platform for which to create a release (e.g. android, ios)
     required: true
@@ -34,12 +34,28 @@ runs:
       id: shorebird-release
       working-directory: ${{ inputs.working-directory }}
       run: |
-        shorebird release ${{ inputs.platform }} --flutter-version ${{ inputs.flutter-version }} ${{ inputs.args }} | tee output.log
-        GREP_MATCH=$(grep -Ei "Published Release (.*)" output.log)
-        if [[ $GREP_MATCH ]]; then
+        set -euo pipefail
+
+        # Sanitize args:
+        # - YAML literal blocks (`|`) preserve newlines, which would break piping.
+        # - Replace newlines with spaces and trim leading/trailing whitespace.
+        ARGS='${{ inputs.args }}'
+        if [[ "$ARGS" == *$'\n'* ]]; then
+          echo "::warning::inputs.args contains newlines; converting them to spaces. Consider using YAML '>-'."
+        fi
+        ARGS="${ARGS//$'\n'/ }"
+        ARGS="$(echo "$ARGS" | awk '{$1=$1; print}')"
+
+        shorebird release '${{ inputs.platform }}' \
+          --flutter-version '${{ inputs.flutter-version }}' \
+          $ARGS \
+          | tee output.log
+
+        GREP_MATCH="$(grep -Ei "Published Release (.*)" output.log || true)"
+        if [[ -n "$GREP_MATCH" ]]; then
           # Strip the non-version-number characters from the line
-          RELEASE_VERSION=$(echo $GREP_MATCH | sed -E 's/^.+ Published Release (.*)\!$/\1/')
-          echo "release-version=$(echo $RELEASE_VERSION)" >> $GITHUB_OUTPUT
+          RELEASE_VERSION="$(echo "$GREP_MATCH" | sed -E 's/^.+ Published Release (.*)\!$/\1/')"
+          echo "release-version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
         else
           echo "Failed to create release"
           exit 1


### PR DESCRIPTION
Fixes the action when `inputs.args` is passed as a YAML literal block (`|`), which preserves newlines. Previously the newlines survived into the `shorebird release ...` command line and broke the invocation.

## Changes

- **Sanitize `inputs.args`:** replace embedded newlines with spaces and trim whitespace before splicing into the command. Emit a `::warning::` telling users to prefer YAML `>-` when newlines are detected.
- **Quote interpolated inputs** (`platform`, `flutter-version`, `GITHUB_OUTPUT`) and add `set -euo pipefail` so failures surface instead of silently continuing.
- **README:** update the example to use `>-` (folded, newline-stripping) for multi-line args.
- Trailing-whitespace cleanup in `action.yml`.

## Context

Reported on Discord: https://discord.com/channels/1030243211995791380/1454769487734902938